### PR TITLE
compile on vs2015

### DIFF
--- a/Anemone/Anemone.vcxproj
+++ b/Anemone/Anemone.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Anemone/TextProcess.cpp
+++ b/Anemone/TextProcess.cpp
@@ -898,7 +898,7 @@ std::wstring CTextProcess::HangulEncode(const std::wstring &input)
 	for (; it != input.end(); it++)
 	{
 		if (*it == L'@' ||
-			(*it == L'') ||
+			(*it == '\0') ||
 			(*it >= 0x1100 && *it <= 0x11FF) || (*it >= 0x3130 && *it <= 0x318F) ||
 			(*it >= 0xA960 && *it <= 0xA97F) || (*it >= 0xAC00 && *it <= 0xD7AF) ||
 			(*it >= 0xD7B0 && *it <= 0xD7FF))
@@ -1729,7 +1729,7 @@ bool CTextProcess::_LoadDic(const wchar_t *dicFile)
 		if (tab < 2) continue;
 
 		// 유효성 검사
-		if (wjpn[0] == L'') continue;
+		if (wjpn[0] == '\0') continue;
 		/*
 		// 우선 적용 단어인 경우
 		if (wpart[0] == L'2')

--- a/Anemone/stdafx.h
+++ b/Anemone/stdafx.h
@@ -57,7 +57,7 @@ using namespace Gdiplus;
 // STL
 #include <string>
 #include <sstream>
-#include <hash_map>
+#include <list>
 
 // control
 #include <commctrl.h>


### PR DESCRIPTION
## remove `L''`

https://msdn.microsoft.com/ko-kr/library/fhxwbt0t%28v=vs.90%29.aspx

to avoid C2137 error.

```
// C2137.cpp
int main() {
   char c = '';   // C2137
   char d = ' ';   // OK
}
```
## remove hash_map from header
1. hash_map is not used now.
2. on visual studio 2015, if hash_map is included, compiler error occur. (use unordered_map instead of hash_map)
## compile on vs2015

Anemone works well on visual studion 2015. (I test and use now.)
