### PR TITLE
문자열 전처리기

### DIFF
--- a/Anemone/Anemone.vcxproj
+++ b/Anemone/Anemone.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Anemone/Anemone.vcxproj
+++ b/Anemone/Anemone.vcxproj
@@ -105,6 +105,7 @@
     <ClInclude Include="Resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="TextPreProcess.h" />
     <ClInclude Include="TextProcess.h" />
     <ClInclude Include="TextRenderer.h" />
     <ClInclude Include="TransEngine.h" />
@@ -120,6 +121,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="TextPreProcess.cpp" />
     <ClCompile Include="TextProcess.cpp" />
     <ClCompile Include="TextRenderer.cpp" />
     <ClCompile Include="TransEngine.cpp" />

--- a/Anemone/Anemone.vcxproj.filters
+++ b/Anemone/Anemone.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="Remocon.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="TextPreProcess.h">
+      <Filter>소스 파일</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -84,6 +87,9 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="Remocon.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="TextPreProcess.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Anemone/TextPreProcess.cpp
+++ b/Anemone/TextPreProcess.cpp
@@ -1,0 +1,100 @@
+#include "stdafx.h"
+#include "TextPreProcess.h"
+#include <cassert>
+#include <regex>
+#include <array>
+#include <functional>
+
+static std::wstring PreProcessFunc_NameExistAndTextNotStartWithName(const std::wstring &text)
+{
+	// 일부 게임의 경우는 후킹된 텍스트의 중간에 이름이 섞여있다.
+	// 【~】 가 문장 중간에 나오면 이을 문장의 처음으로 재배치
+	// 【~】 는 이름을 표시하는데 사용되는 특수문자
+	std::wregex nameExistButNotFirstRegex(L"^.+(【.+】).*$");
+	std::wsmatch m;
+	if (std::regex_match(text, m, nameExistButNotFirstRegex))
+	{
+		if (m.size() >= 2)
+		{
+			int pos = m.position(1);
+			int len = m.length(1);
+			std::wstring bodyHead = text.substr(0, pos);
+			std::wstring name = text.substr(pos, len);
+			std::wstring bodyRemain = text.substr(pos + len, text.length() - pos - len);
+			return (name + bodyHead + bodyRemain);
+		}
+	}
+	return text;
+}
+
+CTextPreProcess::CTextPreProcess()
+{
+
+}
+
+CTextPreProcess::~CTextPreProcess()
+{
+
+}
+
+std::wstring CTextPreProcess::PreProcessText(const std::wstring &input)
+{
+	// Rule 0. 문장이 너무 짧으면 전처리기를 사용하지 않는다
+	const int LOWER_BOUND_FOR_PRE_PROCESS = 2;
+	if (input.empty() || input.length() <= LOWER_BOUND_FOR_PRE_PROCESS)
+	{
+		return input;
+	}
+
+	typedef std::function<std::wstring(std::wstring)> PreProcessFuncType;
+	std::array<PreProcessFuncType, 1> funcs = {
+		PreProcessFunc_NameExistAndTextNotStartWithName,
+	};
+
+	std::wstring text = input;
+	for (auto &func : funcs)
+	{
+		text = func(text);
+	}
+
+	return text;
+}
+
+static int testMainForTextPreProcess()
+{
+	// 전처리기를 간단하게 테스트
+	// 아네모네 기존 코드에는 테스트와 관련된 코드가 없어서 적절히 끼워넣음
+	CTextPreProcess subject;
+	{
+		auto input = L"「も【刑事】?…なんなんだよオマエは…」";
+		auto expected = L"【刑事】「も?…なんなんだよオマエは…」";
+		auto actual = subject.PreProcessText(input);
+		assert(actual == expected);
+	}
+	{
+		auto input = L"「も?…なんなんだよオマエは…」【刑事】";
+		auto expected = L"【刑事】「も?…なんなんだよオマエは…」";
+		auto actual = subject.PreProcessText(input);
+		assert(actual == expected);
+	}
+	{
+		// 전처리가가 작업을 수행하지 않는 경우
+		std::array<std::wstring, 3> inputTexts = {
+			L"【刑事】「も?…なんなんだよオマエは…」",	// 일반 규격 문자열
+			L"123",	// 너무 짧다
+			L"",	// 비어있다 
+		};
+		for (auto &input : inputTexts)
+		{
+			auto actual = subject.PreProcessText(input);
+			assert(actual == input);
+		}
+	}
+	return 0;
+}
+
+#ifdef _DEBUG
+static int __init_test_text_pre_process = testMainForTextPreProcess();
+#endif
+
+

--- a/Anemone/TextPreProcess.h
+++ b/Anemone/TextPreProcess.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+class CTextPreProcess
+{
+public:
+	CTextPreProcess();
+	~CTextPreProcess();
+
+	std::wstring PreProcessText(const std::wstring &input);
+};

--- a/Anemone/TextProcess.cpp
+++ b/Anemone/TextProcess.cpp
@@ -1,5 +1,6 @@
 ﻿#include "StdAfx.h"
 #include "TextProcess.h"
+#include "TextPreProcess.h"
 
 CTextProcess *CTextProcess::m_pThis = NULL;
 
@@ -1406,6 +1407,9 @@ bool CTextProcess::OnDrawClipboardByHooker(wchar_t *lpwszstr)
 
 bool CTextProcess::ProcessText(std::wstring &wContext)
 {
+	CTextPreProcess preProcess;
+	wContext = preProcess.PreProcessText(wContext);
+
 	std::wstring wName, wNameT, wNameR, wText, wTextT, wTextR, wContextT;
 
 

--- a/Anemone/TextProcess.cpp
+++ b/Anemone/TextProcess.cpp
@@ -898,7 +898,7 @@ std::wstring CTextProcess::HangulEncode(const std::wstring &input)
 	for (; it != input.end(); it++)
 	{
 		if (*it == L'@' ||
-			(*it == L'') ||
+			(*it == '\0') ||
 			(*it >= 0x1100 && *it <= 0x11FF) || (*it >= 0x3130 && *it <= 0x318F) ||
 			(*it >= 0xA960 && *it <= 0xA97F) || (*it >= 0xAC00 && *it <= 0xD7AF) ||
 			(*it >= 0xD7B0 && *it <= 0xD7FF))
@@ -1729,7 +1729,7 @@ bool CTextProcess::_LoadDic(const wchar_t *dicFile)
 		if (tab < 2) continue;
 
 		// 유효성 검사
-		if (wjpn[0] == L'') continue;
+		if (wjpn[0] == '\0') continue;
 		/*
 		// 우선 적용 단어인 경우
 		if (wpart[0] == L'2')

--- a/Anemone/stdafx.h
+++ b/Anemone/stdafx.h
@@ -57,7 +57,7 @@ using namespace Gdiplus;
 // STL
 #include <string>
 #include <sstream>
-#include <hash_map>
+#include <list>
 
 // control
 #include <commctrl.h>


### PR DESCRIPTION
1. 일부 게임 (예: 그리자이아의 과실)의 경우 ITHVNR로 후킹한 문자열에 대사와 이름이 섞여있을수 있습니다. 이 경우 이름을 찾아서 문자열의 앞에 재배치하는 함수를 추가했습니다.
2. 아네모네에는 테스트 관련 코드가 없습니다. 전처리기의 테스트를 위해서 디버그 빌드에서만 작동하는 간단한 테스트를 추가했습니다.
3. vs2015 대응 수정은 다른 풀리퀘를 참조하시기바랍니다
