### PR TITLE
폴더 번역 기능 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{c,cpp,h,hpp}]
+indent_style = tab

--- a/Anemone/Anemone.cpp
+++ b/Anemone/Anemone.cpp
@@ -4810,6 +4810,7 @@ DWORD WINAPI FileTransThread(LPVOID lpParam)
 		else
 		{
 			list = list_org;
+			v_line_info.push_back(0);
 		}
 
 		SendMessage(hDlg, WM_COMMAND, ID_FILE_TRANSPROG_LISTSIZE, (LPARAM)list.size());

--- a/Anemone/Library.cpp
+++ b/Anemone/Library.cpp
@@ -296,3 +296,38 @@ bool FontDialog(HWND hWnd, CHOOSEFONT &cf, LOGFONT &lf)
 	}
 	return false;
 }
+
+DWORD EnumerateFiles(const std::wstring& path, std::vector<std::wstring>& files)
+{
+	std::wstring buf{ path };
+	buf += L"\\*";
+	WIN32_FIND_DATA ffd;
+	HANDLE hFind = FindFirstFile(buf.c_str(), &ffd);
+	if (hFind == INVALID_HANDLE_VALUE)
+	{
+		return GetLastError();
+	}
+
+	do
+	{
+		if (_tcscmp(ffd.cFileName, _T(".")) == 0 || _tcscmp(ffd.cFileName, _T("..")) == 0)
+		{
+			continue;
+		}
+		buf = path;
+		buf += L'\\';
+		buf += ffd.cFileName;
+		if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+		{
+			EnumerateFiles(buf, files);
+		}
+		else
+		{
+			files.push_back(move(buf));
+		}
+	} while (FindNextFile(hFind, &ffd) != 0);
+
+	DWORD err = GetLastError();
+	FindClose(hFind);
+	return err;
+}

--- a/Anemone/Library.h
+++ b/Anemone/Library.h
@@ -15,3 +15,4 @@ static BOOL CALLBACK OnGetWindowByProcess(HWND hwnd, LPARAM lParam);
 void ExecuteFile(const std::wstring &filename);
 bool ColorDialog(HWND hWnd, CHOOSECOLOR &cc, DWORD ColorVar);
 bool FontDialog(HWND hWnd, CHOOSEFONT &cf, LOGFONT &lf);
+DWORD EnumerateFiles(const std::wstring& path, std::vector<std::wstring>& files);

--- a/Anemone/stdafx.h
+++ b/Anemone/stdafx.h
@@ -28,6 +28,8 @@
 #include <process.h>
 
 // C 런타임 헤더 파일입니다.
+#include <codecvt>
+#include <fstream>
 #include <ios>
 #include <tchar.h>
 #include <vector>
@@ -178,8 +180,6 @@ typedef struct
 {
 	std::vector<std::wstring> v_inputFiles;
 	std::vector<std::wstring> v_outputFiles;
-	std::vector<FILE *> v_fpw;
-	std::vector<FILE *> v_fpr;
 	int WriteType;
 	bool NoTransLineFeed;
 	int StartTickCount;


### PR DESCRIPTION
텍스트 파일 번역 기능으로 파일 선택 시 폴더 이름을 하단 에디트에 입력하고 열기 버튼을 누르면 폴더가 선택되어 해당 경로의 파일 전체를 번역합니다.
폴더를 더블클릭하면 선택되는 게 아니라 그 폴더 안으로 들어가기에 사용법 설명이 필요합니다.